### PR TITLE
Feat/add new makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,64 @@
-.PHONY: setup build clean
+.PHONY: setup build clean switch switchx update clean-nix check-updates show-updates
 
-setup:
+HOSTNAME := $(shell hostname -s) # Use short hostname for consistency with aliases
+
+setup: ## Install Homebrew and Nix
 	@echo "Setting up environment..."
 	# Check if Homebrew is installed
 	if ! command -v brew >/dev/null 2>&1; then \
 		echo "Homebrew not found. Installing Homebrew..."; \
-		/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" || exit 1; \
-	else 
-		echo "Homebrew is already installed."; 
+		/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; \
+	else \
+		echo "Homebrew is already installed."; \
 	fi
 	# Check if Nix is installed
 	if ! command -v nix >/dev/null 2>&1; then \
 		echo "Nix not found. Installing Nix..."; \
-		curl -L https://nixos.org/nix/install | sh || exit 1; \
-	else 
-		echo "Nix is already installed."; 
+		curl -L https://nixos.org/nix/install | sh; \
+	else \
+		echo "Nix is already installed."; \
 	fi
 	@echo "Setup complete!"
 
-build:
-	@echo "Building Nix configuration for $(shell hostname)..."
-	sudo darwin-rebuild switch --flake .#$(shell hostname)
+build: switchx ## Apply Nix-Darwin configuration (default build)
 	@echo "Build complete!"
 
-clean:
-	@echo "Cleaning up..."
+switch: ## Apply Nix-Darwin configuration with Cachix
+	@echo "Applying Nix configuration for $(HOSTNAME) with Cachix..."
+	cachix watch-exec zmre darwin-rebuild -- switch --flake .#$(HOSTNAME)
+
+switchx: ## Apply Nix-Darwin configuration without Cachix
+	@echo "Applying Nix configuration for $(HOSTNAME) without Cachix..."
+	darwin-rebuild switch --flake .#$(HOSTNAME)
+
+update: switch ## Update flake inputs, Homebrew, and apply Nix configuration
+	@echo "Updating flake inputs and Homebrew..."
+	nix flake update
+	/opt/homebrew/bin/brew update
+	/opt/homebrew/bin/brew upgrade
+	/opt/homebrew/bin/brew upgrade --cask --greedy
+	$(MAKE) show-updates # Call show-updates target
+
+clean: ## Clean up build artifacts
+	@echo "Cleaning up build artifacts..."
 	rm -rf result
 	@echo "Clean complete!"
+
+clean-nix: ## Clean up Nix generations and garbage collect
+	@echo "Cleaning up Nix environment..."
+	sudo nix-env --delete-generations +7 --profile /nix/var/nix/profiles/system
+	sudo nix-collect-garbage --delete-older-than 30d
+	nix store optimise
+	@echo "Nix cleanup complete!"
+
+check-updates: ## Check for Nix and Homebrew updates
+	@echo "Checking for Nix and Homebrew updates..."
+	nix flake update
+	darwin-rebuild build --flake .#$(HOSTNAME) && nix store diff-closures /nix/var/nix/profiles/system result
+	/opt/homebrew/bin/brew update >& /dev/null && /opt/homebrew/bin/brew upgrade -n -g
+	@echo "Update check complete!"
+
+show-updates: ## Show diff between current and previous Nix system generations
+	@echo "Showing Nix system generation diff..."
+	zsh -c "nix store diff-closures /nix/var/nix/profiles/system-*-link(om[2]) /nix/var/nix/profiles/system-*-link(om[1])"
+	@echo "Nix system generation diff complete!"

--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756496801,
-        "narHash": "sha256-IYIsnPy+cJxe8RbDHBrCtfJY0ry2bG2H7WvMcewiGS8=",
+        "lastModified": 1756659230,
+        "narHash": "sha256-RN1iazeBtnZb6nzDkFLeTTaWPzRk0FFTv565A7AP1yg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "77a71380c38fb2a440b4b5881bbc839f6230e1cb",
+        "rev": "f27974d3b4aa0af533539ce626622c7b6b53c3f5",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756510930,
-        "narHash": "sha256-TX+1q0BxjFmEMpJKfjWvZA06ou4RH8oHFFNc4n9Skw0=",
+        "lastModified": 1756662433,
+        "narHash": "sha256-YBzCInzMnxT/7PY6SkLZIJd+9b5KE8pI/GbF+QvSfVI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "221449eb819165510a6851215a02e4735507f99c",
+        "rev": "2119cb39e0cf9f00e06a5c250fd9eae42d0c9edf",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,11 +3,9 @@
 
   inputs = {
     # Specify the source of Home Manager and Nixpkgs.
-  #  nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    # nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
-     nixpkgs.url = "github:NixOS/nixpkgs/master";
-
-
+    nixpkgs.url = "github:NixOS/nixpkgs/master";
 
     darwin.url = "github:lnl7/nix-darwin";
     darwin.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
This pull request significantly enhances the `Makefile` by introducing new targets for managing Nix and Homebrew environments, improving usability, and making environment setup and updates more robust. Additionally, it makes a minor cleanup in `flake.nix`. The most important changes are grouped below:

**Makefile improvements and new targets:**

* Added several new targets to the `Makefile` for common Nix and Homebrew operations, including `switch`, `switchx`, `update`, `clean-nix`, `check-updates`, and `show-updates`, making environment management easier and more comprehensive.
* Updated the `setup` target to provide clearer feedback and ensure both Homebrew and Nix are installed, improving reliability during initial setup.
* Refactored the `build` target to use the new `switchx` target, clarifying the default build process.
* Enhanced the `clean` target and added `clean-nix` to provide more thorough cleanup options, including Nix garbage collection.

**Minor cleanup:**

* Removed extra blank lines in `flake.nix` for improved readability.