### PR TITLE
feat(nix): add zj-quit and update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,6 +2,21 @@
   "nodes": {
     "crane": {
       "locked": {
+        "lastModified": 1731098351,
+        "narHash": "sha256-HQkYvKvaLQqNa10KEFGgWHfMAbWBfFp+4cAgkut+NNE=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "ef80ead953c1b28316cc3f8613904edc2eb90c28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_2": {
+      "locked": {
         "lastModified": 1754269165,
         "narHash": "sha256-0tcS8FHd4QjbCVoxN9jI+PjHgA4vc/IjkUSp+N3zy0U=",
         "owner": "ipetkov",
@@ -89,6 +104,24 @@
         "type": "github"
       }
     },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "helix-themes": {
       "inputs": {
         "flake-utils": "flake-utils_2",
@@ -153,10 +186,32 @@
         "helix-themes": "helix-themes",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
+        "zj-quit": "zj-quit",
         "zjstatus": "zjstatus"
       }
     },
     "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "zj-quit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731637922,
+        "narHash": "sha256-6iuzRINXyPX4DfUQZIGafpJnzjFXjVRYMymB10/jFFY=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "db10c66da18e816030b884388545add8cf096647",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
       "inputs": {
         "nixpkgs": [
           "zjstatus",
@@ -222,7 +277,22 @@
         "type": "github"
       }
     },
-    "zjstatus": {
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "zj-quit": {
       "inputs": {
         "crane": "crane",
         "flake-utils": "flake-utils_3",
@@ -230,6 +300,29 @@
           "nixpkgs"
         ],
         "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1731685894,
+        "narHash": "sha256-BeEakFB/SfpThhH7c2yFoJ6g2TQVAfBa4N7Dr8d8SZY=",
+        "owner": "dj95",
+        "repo": "zj-quit",
+        "rev": "85dd8df8725b2f7de647a8ac63beabc59ee968a5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dj95",
+        "repo": "zj-quit",
+        "type": "github"
+      }
+    },
+    "zjstatus": {
+      "inputs": {
+        "crane": "crane_2",
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay_2"
       },
       "locked": {
         "lastModified": 1754932774,

--- a/flake.lock
+++ b/flake.lock
@@ -40,6 +40,24 @@
         "systems": "systems"
       },
       "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
         "lastModified": 1710146030,
         "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
@@ -53,9 +71,9 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
+    "flake-utils_3": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -73,7 +91,7 @@
     },
     "helix-themes": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -114,16 +132,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756662818,
-        "narHash": "sha256-Opggp4xiucQ5gBceZ6OT2vWAZOjQb3qULv39scGZ9Nw=",
+        "lastModified": 1756696532,
+        "narHash": "sha256-6FWagzm0b7I/IGigOv9pr6LL7NQ86mextfE8g8Q6HBg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2e6aeede9cb4896693434684bb0002ab2c0cfc09",
+        "rev": "58dcbf1ec551914c3756c267b8b9c8c86baa1b2f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "master",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -131,6 +149,7 @@
     "root": {
       "inputs": {
         "darwin": "darwin",
+        "flake-utils": "flake-utils",
         "helix-themes": "helix-themes",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
@@ -188,10 +207,25 @@
         "type": "github"
       }
     },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "zjstatus": {
       "inputs": {
         "crane": "crane",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": [
           "nixpkgs"
         ],

--- a/flake.nix
+++ b/flake.nix
@@ -2,71 +2,77 @@
   description = "Home Manager configuration of Lucas Santanna";
 
   inputs = {
-    # Specify the source of Home Manager and Nixpkgs.
-    # nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-
-    nixpkgs.url = "github:NixOS/nixpkgs/master";
-
-    darwin.url = "github:lnl7/nix-darwin";
-    darwin.inputs.nixpkgs.follows = "nixpkgs";
-
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-
+    darwin = {
+      url = "github:lnl7/nix-darwin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-utils.url = "github:numtide/flake-utils";
     helix-themes = {
       url = "github:eureka-cpu/helix-themes.nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-
     zjstatus = {
       url = "github:dj95/zjstatus";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
-  outputs = inputs@{ nixpkgs, home-manager, darwin, zjstatus, ... }: rec {
-    # Helper function to create Darwin configurations
-    createDarwinConfig = { name, system, username }: darwin.lib.darwinSystem {
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [
-          (final: prev: {
-            zjstatus = zjstatus.packages.${prev.system}.default;
-          })
-        ];
+  outputs = inputs@{ self, nixpkgs, home-manager, darwin, ... }:
+    let
+      lib = nixpkgs.lib;
+
+      # Define hosts and their systems
+      hosts = {
+        "lucass-MacBook-Pro" = "x86_64-darwin";
+        "fg-lstanaanna" = "aarch64-darwin";
       };
-      specialArgs = { inherit inputs; }; # Pass inputs to modules
-      modules = [
+
+      # Common modules for all systems
+      commonModules = system: [
+        { nixpkgs.overlays = [ (final: prev: { zjstatus = inputs.zjstatus.packages.${system}.default; }) ]; }
         ./modules/darwin
         home-manager.darwinModules.home-manager
         {
-          home-manager = {
-            useGlobalPkgs = true;
-            useUserPackages = true;
-            users."${username}".imports = [ ./modules/home-manager ];
-            extraSpecialArgs = { inherit inputs; }; # Pass inputs to home-manager modules
-          };
+          home-manager.useGlobalPkgs = true;
+          home-manager.useUserPackages = true;
+          home-manager.users.lucas.imports = [ ./modules/home-manager ];
+          home-manager.extraSpecialArgs = { inherit inputs; };
         }
       ];
-    };
 
-    darwinConfigurations = {
-      # Configuration matching the expected system name
-      "lucass-MacBook-Pro" = createDarwinConfig {
-        name = "lucass-MacBook-Pro";  # Matching the expected system name
-        system = "x86_64-darwin";      # Change to "aarch64-darwin" if needed
-        username = "lucas";
-      };
+      systems = [ "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      # Generate darwinConfigurations from hosts
+      darwinConfigurations = lib.mapAttrs (hostName: system:
+        darwin.lib.darwinSystem {
+          inherit system;
+          specialArgs = { inherit inputs; };
+          modules = commonModules system;
+        }
+      ) hosts;
 
-      # Example configuration for an ARM architecture, adjust as needed
-      "fg-lstanaanna" = createDarwinConfig {
-        name = "fg-lstanaanna";
-        system = "aarch64-darwin";
-        username = "lucas";
-      };
+      packages = forAllSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [
+              (final: prev: {
+                zjstatus = inputs.zjstatus.packages.${prev.system}.default;
+              })
+            ];
+          };
+        in
+        {
+          inherit pkgs;
+        }
+      );
     };
-  };
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,10 @@
       url = "github:dj95/zjstatus";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    zj-quit = {
+      url = "github:dj95/zj-quit";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = inputs@{ self, nixpkgs, home-manager, darwin, ... }:
@@ -32,9 +36,15 @@
         "fg-lstanaanna" = "aarch64-darwin";
       };
 
+      # Common overlay for zjstatus and zj-quit
+      commonOverlay = final: prev: {
+        zjstatus = inputs.zjstatus.packages.${prev.system}.default;
+        zj-quit = inputs.zj-quit.packages.${prev.system}.default;
+      };
+
       # Common modules for all systems
-      commonModules = system: [
-        { nixpkgs.overlays = [ (final: prev: { zjstatus = inputs.zjstatus.packages.${system}.default; }) ]; }
+      commonModules = [
+        { nixpkgs.overlays = [ commonOverlay ]; }
         ./modules/darwin
         home-manager.darwinModules.home-manager
         {
@@ -54,7 +64,7 @@
         darwin.lib.darwinSystem {
           inherit system;
           specialArgs = { inherit inputs; };
-          modules = commonModules system;
+          modules = commonModules;
         }
       ) hosts;
 
@@ -62,11 +72,7 @@
         let
           pkgs = import nixpkgs {
             inherit system;
-            overlays = [
-              (final: prev: {
-                zjstatus = inputs.zjstatus.packages.${prev.system}.default;
-              })
-            ];
+            overlays = [ commonOverlay ];
           };
         in
         {
@@ -75,4 +81,3 @@
       );
     };
 }
-

--- a/modules/home-manager/modules/zsh.nix
+++ b/modules/home-manager/modules/zsh.nix
@@ -42,6 +42,7 @@
       # Setup zoxidec
       eval "$(zoxide init zsh)"
       path+=/Users/lucas/bin
+      export GPG_TTY=$(tty)
 
       export SDKMAN_DIR="$HOME/.sdkman"
       [[ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]] && source "$HOME/.sdkman/bin/sdkman-init.sh"


### PR DESCRIPTION
This commit introduces the `zj-quit` input to the Nix flake and updates existing flake inputs.
A common overlay `commonOverlay` has been added to manage `zjstatus` and `zj-quit` packages,
ensuring consistent integration across the system.

This change improves the overall flake management and adds new functionality.